### PR TITLE
Update Version Number to 5.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(GenerateExportHeader)
 include(CMakePackageConfigHelpers)
 
 set(P7_MAJOR_VERSION 5)
-set(P7_MINOR_VERSION 0)
+set(P7_MINOR_VERSION 2)
 set(P7_PATCH_VERSION 0)
 set(P7_VERSION ${P7_MAJOR_VERSION}.${P7_MINOR_VERSION}.${P7_PATCH_VERSION})
 


### PR DESCRIPTION
Hello,

First of all, thanks for this CMake Port, it is very useful.

I noticed that the versions defined with `P7_MAJOR_VERSION`, `P7_MINOR_VERSION`, and `P7_PATCH_VERSION` are still at 5.0.0, while the current version is 5.2.0. This commit updates the version, so the version number is correct.

Is this ok?

Best regards